### PR TITLE
test: RGB Spring2019 Pass2 initial tests

### DIFF
--- a/datasetList.txt
+++ b/datasetList.txt
@@ -1,15 +1,23 @@
-rga_inbending 5032 5419 /cache/clas12/rg-a/production/recon/fall2018/torus-1/pass1/v0/dst/recon
+# RGA
+rga_inbending  5032 5419 /cache/clas12/rg-a/production/recon/fall2018/torus-1/pass1/v0/dst/recon
 rga_outbending 5422 5666 /cache/clas12/rg-a/production/recon/fall2018/torus+1/pass1/v0/dst/recon
-rga_spring19 6616 6783 /cache/clas12/rg-a/production/recon/spring2019/torus-1/pass1/v0/dst/recon
+rga_spring19   6616 6783 /cache/clas12/rg-a/production/recon/spring2019/torus-1/pass1/v0/dst/recon
+# tests:
 rga_pass0_early 4763 5001 /cache/clas12/rg-a/production/recon/fall2018/torus-1/pass1/v0b/dst/recon
 
-rgb_spring 6156 6603 /cache/clas12/rg-b/production/recon/spring2019/torus-1/pass1/v0/dst/recon
-rgb_fall 11093 11300 /cache/clas12/rg-b/production/recon/fall2019/torus+1/pass1/v1/dst/recon
+# RGB
+rgb_spring 6156  6603  /cache/clas12/rg-b/production/recon/spring2019/torus-1/pass1/v0/dst/recon
+rgb_fall   11093 11300 /cache/clas12/rg-b/production/recon/fall2019/torus+1/pass1/v1/dst/recon
 rgb_winter 11323 11571 /cache/clas12/rg-b/production/recon/spring2020/torus-1/pass1/v1/dst/recon
+# tests:
+rgb_pass2_test_newCVT      6449 6567 /volatile/clas12/rg-b/production/recon/pass0/v28.22_8c.3.2/dst/recon/
+rgb_pass2_test_standardCVT 6449 6567 /volatile/clas12/rg-b/production/recon/pass0/v28.22_8.3.2/dst/recon/
 
+# RGK
 rgk_7 5674 5870 /lustre19/expphy/cache/clas12/rg-k/production/recon/fall2018/torus+1/7546MeV/pass1/v0/dst/recon
 rgk_6 5875 6000 /lustre19/expphy/cache/clas12/rg-k/production/recon/fall2018/torus+1/6535MeV/pass1/v0/dst/recon 
 
+# RGF
 rgf_spring20_torusM1 12210 12329 /cache/clas12/rg-f/production/recon/spring2020/torus-1_solenoid-0.8/pass1v0/dst/recon
 rgf_summer20_torusPh 12389 12434 /cache/clas12/rg-f/production/recon/summer2020/torus+0.5_solenoid-0.745/pass1v0/dst/recon
 rgf_summer20_torusMh 12436 12443 /cache/clas12/rg-f/production/recon/summer2020/torus-0.5_solenoid-0.745/pass1v0/dst/recon


### PR DESCRIPTION
Adds datasets for RGB pass2 tests: https://github.com/c-dilks/clasqa/blob/8c00e1f33bb5ed2d3df8789b34a4950b2d3030e0/datasetList.txt#L13-L14

Also formats `datasetList.txt` to make it easier to read

**IMPORTANT** run with an older version of `coatjava` (temporary workaround for `groot` backward incompatibility):
```
module switch coatjava/6.5.9
```