### PR TITLE
fix: ignore empty DAQ events

### DIFF
--- a/monitorRead.groovy
+++ b/monitorRead.groovy
@@ -763,9 +763,9 @@ inHipoList.each { inHipoFile ->
       }
     }
 
-    // add eventNum to the list of this segment's event numbers
+    // add eventNum to the list of this segment's event numbers; ignore empty events (eventNum==0)
     eventNum = BigInteger.valueOf(configBank.getInt('event',0))
-    eventNumList.add(eventNum)
+    if(eventNum>0) eventNumList.add(eventNum)
 
   } // end event loop
   reader.close()


### PR DESCRIPTION
From Raffaella:
> we do have routinely events with number 0 that are created by the DAQ and are empty. If you don’t, you should probably ignore them and set the event minimum by looking only at events whose number is >0.